### PR TITLE
feat: devcontainer, fix: estimator_node.cpp build failing in docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/cpp
+{
+	"name": "r2live-dev",
+	"build": {
+		"dockerfile": "../docker/Dockerfile",
+		"context": ".."
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+		// "args": { "VARIANT": "ubuntu-20.04" }
+	},
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+	"overrideCommand": true,
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.cpptools",
+		"github.copilot"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "root"
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM ros:melodic-ros-core-bionic
 
+SHELL ["/bin/bash","-c"]
+
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
@@ -10,7 +12,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # bootstrap rosdep
 RUN rosdep init && \
-  rosdep update --rosdistro $ROS_DISTRO
+    rosdep update --rosdistro $ROS_DISTRO
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -18,21 +20,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # r2live stuff
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-melodic-cv-bridge ros-melodic-tf ros-melodic-message-filters ros-melodic-image-transport \ 
     ros-melodic-pcl-conversions ros-melodic-pcl-ros ros-melodic-perception ros-melodic-octomap-*
 
 # build tools and libraries
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libgoogle-glog-dev libatlas-base-dev libeigen3-dev cmake \
-    curl wget vim build-essential unzip mesa-utils libgl1-mesa-glx
+    curl wget vim build-essential unzip mesa-utils libgl1-mesa-glx && \
+    rm -rf /var/lib/apt/lists/*
 
 # ceres solver
 WORKDIR /opt/ceres_build
 
 RUN wget -O ceres.zip https://github.com/ceres-solver/ceres-solver/archive/1.14.0.zip \
     && unzip ceres.zip
- 
+
 RUN cd ceres-solver-1.14.0 && mkdir ceres-bin && cd ceres-bin \
     && cmake .. && make install -j4
 
@@ -46,7 +49,7 @@ RUN cd Livox-SDK-2.3.0/build && cmake .. && make && make install
 
 RUN wget -O livox_ros_driver.zip https://github.com/Livox-SDK/livox_ros_driver/archive/refs/tags/v2.6.0.zip && mkdir -p ws_livox/src && unzip livox_ros_driver.zip -d ws_livox/src
 
-RUN /bin/bash -c '. /opt/ros/melodic/setup.bash; cd ws_livox && catkin_make'
+RUN source /opt/ros/melodic/setup.bash; cd ws_livox && catkin_make
 
 # r2live build
 WORKDIR /opt/catkin_ws/src
@@ -60,7 +63,7 @@ RUN    mv /usr/include/flann/ext/lz4.h /usr/include/flann/ext/lz4.h.bak \
 
 ADD . .
 
-RUN /bin/bash -c '. /opt/ros/melodic/setup.bash; cd ../ && catkin_make'
+RUN source /opt/ros/melodic/setup.bash; cd ../ && catkin_make -j1
 
 ADD docker/ros-entrypoint.sh /ros-entrypoint.sh
 ENTRYPOINT [ "/ros-entrypoint.sh" ]


### PR DESCRIPTION
fixed build error on docker:

`recipe for target 'r2live/CMakeFiles/r2live.dir/src/estimator_node.cpp.o' failed`
- this used to come up randomly, possibly due to some race condition in building the docker image, its now fixed

added devcontainer

- its now much easier to develop inside the docker environment ! use vscode devcontainers !